### PR TITLE
1 problem with using raw data

### DIFF
--- a/adpbulk/__init__.py
+++ b/adpbulk/__init__.py
@@ -1,5 +1,5 @@
 """Pseudo-Bulking Single-Cell RNA-seq"""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .adpbulk import ADPBulk

--- a/adpbulk/adpbulk.py
+++ b/adpbulk/adpbulk.py
@@ -164,6 +164,15 @@ class ADPBulk:
             mat = self.adat.X[mask]
         return self.agg_methods[self.method](mat, axis=0)
 
+    def _get_var(self) -> np.ndarray:
+        """
+        return the var names using the given scheme (normal/raw)
+        """
+        if self.use_raw:
+            return self.adat.raw.var.index.values
+        else:
+            return self.adat.var.index.values
+
     def _prepare_meta(self, pairs: tuple) -> dict:
         """
         defines the meta values for the pairs
@@ -232,7 +241,7 @@ class ADPBulk:
         self.matrix = pd.DataFrame(
             matrix,
             index=self.meta.SampleName.values,
-            columns=self.adat.var.index.values)
+            columns=self._get_var())
 
         self._istransform = True
         return self.matrix

--- a/tests/test_adpbulk.py
+++ b/tests/test_adpbulk.py
@@ -83,15 +83,20 @@ def test_adjusted_raw():
     after the original adat changes but the raw does not
     """
     adat = build_adat()
-    mask = np.random.random(adat.shape[1]) < 0.7
+    mask = np.random.random(SIZE_M) < 0.3
     adat = adat[:, mask].copy()
+
+    # confirm that `var` shapes are incompatible
+    assert adat.shape[1] != adat.raw.shape[1]
 
     # tests singular group conditions
     for group in adat.obs.columns:
-        _ = ADPBulk(adat, groupby=group, use_raw=True)
+        adpb = ADPBulk(adat, groupby=group, use_raw=True)
+        adpb.fit_transform()
 
     # tests multiple group conditions
-    _ = ADPBulk(adat, groupby=["cA", "cD"], use_raw=True)
+    adpb = ADPBulk(adat, groupby=["cA", "cD"], use_raw=True)
+    adpb.fit_transform()
 
     assert True
 

--- a/tests/test_adpbulk.py
+++ b/tests/test_adpbulk.py
@@ -77,6 +77,25 @@ def test_init_raw():
     assert True
 
 
+def test_adjusted_raw():
+    """
+    tests whether the ADPBulk object can be run correctly
+    after the original adat changes but the raw does not
+    """
+    adat = build_adat()
+    mask = np.random.random(adat.shape[1]) < 0.7
+    adat = adat[:, mask].copy()
+
+    # tests singular group conditions
+    for group in adat.obs.columns:
+        _ = ADPBulk(adat, groupby=group, use_raw=True)
+
+    # tests multiple group conditions
+    _ = ADPBulk(adat, groupby=["cA", "cD"], use_raw=True)
+
+    assert True
+
+
 def test_init_missing_group():
     """
     tests whether the ADPBulk object be init incorrectly


### PR DESCRIPTION
Fixes bug where if variable names change in original anndata but not in raw (like if you were comparing highly variable genes) `transform` would fail with `IndexError`

close #1 